### PR TITLE
install.sh fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,22 +8,22 @@ OS=`uname`
 
 #BACKUP FILE NAMES
 bext=`date +_%T_%F.old`
-if [ $OS == Linux ] ; then 
+if [ $OS = Linux ] ; then 
        backupargs="-bS $bext"
-elif [ $OS == FreeBSD ] ; then
+elif [ $OS = FreeBSD ] ; then
        backupargs="-bB $bext"
 else backupargs="";
 fi
 
 
 #SOME FUNCTIONS
-function sure? {
-	read -p" (y/N)? " 
+sure () {
+	read REPLY
 	echo
 	test $REPLY = "y" || test $REPLY = "Y"
 }
 
-function make_dir {
+make_dir () {
 	  test -d $1 || {
 		  echo "    creating: $1"
 		  mkdir $1
@@ -31,16 +31,16 @@ function make_dir {
   	}
 }
 
-function copyfile {
+copyfile () {
 	echo "    installing: $2/$1"
 	install $backupargs $1 $2/$1
 }
 
-function copydir {
+copydir () {
 	files=`ls $1`
 	for i in $files; do 
 		echo "    installing: $2/$i"
-		if [[ -d $1/$i ]]; then
+		if [ -d $1/$i ]; then
 			mkdir -p $2/$i
 			copydir $1/$i $2/$i
 		else
@@ -58,8 +58,8 @@ Vim Outliner Installation
     recovery of any of the old files.
 
 EOT
-echo -n "Would you like to continue "
-sure? || exit
+echo -n "Would you like to continue (y/N) ? "
+sure || exit
 
 
 #CREATE NECESSARY DIRECTORIES
@@ -137,15 +137,15 @@ Add-ons
 
 EOT
 
-echo -n "Would you like to install these "
-if sure?; then
+echo -n "Would you like to install these (y/N) "
+if sure; then
 	echo installing add-ons
 	copydir vimoutliner/plugin $vodir/plugin
 	copydir vimoutliner/scripts $vodir/scripts
 fi
 
 #ALL DONE
-echo installation complete
+echo Installation complete
 
 cat <<EOT
 


### PR DESCRIPTION
'sh install.sh' fails under Ubuntu because /bin/sh points to dash and install.sh seems to be written for bash.
This commit makes install.sh work with bash, dash and ksh.
