### PR TITLE
Replaced len() so it works with multibyte chars.

### DIFF
--- a/doc/votl_readme.txt
+++ b/doc/votl_readme.txt
@@ -1038,7 +1038,7 @@ You cannot hoist parts of an already hoisted file again.
 To enable this plugin uncomment the following line in
  ~/.vimoutlinerrc:
 >
-    "let g:votl_modules_load .= ':hoist'
+    "let g:vo_modules_load .= ':hoist'
 <
 Once it is enabled, you hoist the subtopics of the currently selected
 item with


### PR DESCRIPTION
Characters such as "é" were counted as two, e.g. len("é") would return "2". Using strdisplaywidth() instead of strlen() and len() gives us the correct length (also considers "^I", that is, tab characters).
