### PR TITLE
Fix python script crunchbang lines

### DIFF
--- a/vimoutliner/scripts/otl2html.py
+++ b/vimoutliner/scripts/otl2html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otl2html.py
 # convert a tab-formatted outline from VIM to HTML
 #

--- a/vimoutliner/scripts/otl2ooimpress.py
+++ b/vimoutliner/scripts/otl2ooimpress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otl2ooimpress.py
 # needs otl2ooimpress.sh to work in an automated way
 #############################################################################

--- a/vimoutliner/scripts/otl2table.py
+++ b/vimoutliner/scripts/otl2table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otl2table.py
 # convert a tab-formatted outline from VIM to tab-delimited table
 #

--- a/vimoutliner/scripts/otl2tags.py
+++ b/vimoutliner/scripts/otl2tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otl2tags.py
 # Convert an OTL file to any tags-based file using config user-
 # definable configuration files. HTML, OPML, XML, LATEX and

--- a/vimoutliner/scripts/otlgrep.py
+++ b/vimoutliner/scripts/otlgrep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otlgrep.py
 # grep an outline for a regex and return the branch with all the leaves.
 #

--- a/vimoutliner/scripts/otlsplit.py
+++ b/vimoutliner/scripts/otlsplit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # otlslit.py
 # split an outline into several files.
 #

--- a/vimoutliner/scripts/outline_freemind/freemind.py
+++ b/vimoutliner/scripts/outline_freemind/freemind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 '''
 usage:

--- a/vimoutliner/scripts/outline_freemind/freemind_outline.py
+++ b/vimoutliner/scripts/outline_freemind/freemind_outline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 '''Converts a freemind xml .mm file to an outline file compatable with vim 
 outliner.
 

--- a/vimoutliner/scripts/outline_freemind/outline_freemind.py
+++ b/vimoutliner/scripts/outline_freemind/outline_freemind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 '''Read in an otl file and generate an xml mind map viewable in freemind
 
 Make sure that you check that round trip on your file works.


### PR DESCRIPTION
Change the crunchbang lines from /usr/bin/python to /usr/bin/python2,
since most distros are moving on, and the current release is python3, so
it is reasonable that /usr/bin/python has been symlinked to
/usr/bin/python3.
