### PR TITLE
Don't munge maplocalleader, at least not per default. 

### DIFF
--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -31,7 +31,7 @@ let b:current_syntax = "outliner"
 
 " User Preferences {{{1
 
-let maplocalleader = ",,"		" this is prepended to VO key mappings
+"let maplocalleader = ",,"		" this is prepended to VO key mappings
 
 "setlocal ignorecase			" searches ignore case
 "setlocal smartcase			" searches use smart case


### PR DESCRIPTION
Given that 0.3.7 is hopefully getting close, I think it is a time for me to post here patches we had in Fedora packages.

This one is really old. I had couple of flamewars about this on the email list with Steve and Noel, but I still believe that this redefinition of the default behavior is The Bad Thing™ to do. See

http://thread.gmane.org/gmane.comp.editors.vim.outliner/3524/
http://thread.gmane.org/gmane.comp.editors.vim.outliner/3514/focus=3521

for couple of exchanges on this theme.
