### PR TITLE
Fix for user-defined <localleader> for command mappings.

### DIFF
--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -27,7 +27,12 @@
 "endif
 "let b:did_ftplugin = 1
 let b:current_syntax = "outliner"
+
+" Default Preferences {{{1
+
 let use_space_colon=0
+
+" End User Preferences
 
 " VimOutliner Standard Settings {{{1
 setlocal autoindent	
@@ -37,11 +42,11 @@ setlocal wrap
 setlocal tw=78
 setlocal noexpandtab
 setlocal tabstop=4			" tabstop and shiftwidth must match
-setlocal shiftwidth=4		" values from 2 to 8 work well
+setlocal shiftwidth=4			" values from 2 to 8 work well
 "setlocal nosmarttab
 "setlocal softtabstop=0 
 setlocal foldlevel=20
-setlocal foldcolumn=1		" turns on "+" at the beginning of close folds
+setlocal foldcolumn=1			" turns on "+" at the beginning of close folds
 setlocal foldmethod=expr
 setlocal foldexpr=MyFoldLevel(v:lnum)
 setlocal indentexpr=
@@ -535,70 +540,6 @@ set foldtext=MyFoldText()
 endif " if !exists("loaded_vimoutliner_functions")
 " End Vim Outliner Functions
 
-" Vim Outliner Key Mappings {{{1
-" insert the date
-nmap <silent><buffer> <localleader>d $:call InsertSpaceDate()<cr>
-imap <silent><buffer> <localleader>d ~<esc>x:call InsertDate(0)<cr>a
-nmap <silent><buffer> <localleader>D ^:call InsertDate(1)<cr>a <esc>
-
-
-" insert the time
-nmap <silent><buffer> <localleader>t $:call InsertSpaceTime()<cr>
-imap <silent><buffer> <localleader>t ~<esc>x:call InsertTime(0)<cr>a
-nmap <silent><buffer> <localleader>T ^:call InsertTime(1)<cr>a <esc>
-
-" sort a list naturally
-map <silent> <buffer> <localleader>s :silent call SortChildren(0)<cr>
-" sort a list, but you supply the options
-map <silent> <buffer> <localleader>S :silent call SortChildren(1)<cr>
-
-" invoke the file explorer
-map <silent><buffer> <localleader>f :e .<cr>
-imap <silent><buffer> <localleader>f :e .<cr>
-
-" Insert a fence for segmented lists.
-" I also use this divider to create a <hr> when converting to html
-map <silent><buffer> <localleader>- o----------------------------------------0
-imap <silent><buffer> <localleader>- ----------------------------------------<cr>
-
-" switch document between the two types of bodytext styles
-if use_space_colon == 1
-  "   First, convert document to the marker style
-  map <silent><buffer><localleader>b :%s/\(^\t*\) :/\1/e<cr>:%s/\(^\t*\) /\1 : /e<cr>:let @/=""<cr>
-  "   Now, convert document to the space style
-  map <silent><buffer><localleader>B :%s/\(^\t*\) :/\1/e<cr>:let @/=""<cr>
-else
-  "   First, convert document to the marker style
-  map <silent><buffer><localleader>b :%s/\(^\t*\):/\1/e<cr>:%s/\(^\t*\) /\1: /e<cr>:let @/=""<cr>
-  "   Now, convert document to the space style
-  map <silent><buffer><localleader>B :%s/\(^\t*\):/\1/e<cr>:let @/=""<cr>
-endif
-
-" Steve's additional mappings start here
-map <silent><buffer>   <C-K>         <C-]>
-map <silent><buffer>   <C-N>         <C-T>
-map <silent><buffer>   <localleader>0           :set foldlevel=99999<CR>
-map <silent><buffer>   <localleader>9           :set foldlevel=8<CR>
-map <silent><buffer>   <localleader>8           :set foldlevel=7<CR>
-map <silent><buffer>   <localleader>7           :set foldlevel=6<CR>
-map <silent><buffer>   <localleader>6           :set foldlevel=5<CR>
-map <silent><buffer>   <localleader>5           :set foldlevel=4<CR>
-map <silent><buffer>   <localleader>4           :set foldlevel=3<CR>
-map <silent><buffer>   <localleader>3           :set foldlevel=2<CR>
-map <silent><buffer>   <localleader>2           :set foldlevel=1<CR>
-map <silent><buffer>   <localleader>1           :set foldlevel=0<CR>
-map <silent><buffer>   <localleader>,,          :runtime vimoutliner/vimoutlinerrc<CR>
-map! <silent><buffer>  <localleader>w           <Esc>:w<CR>a
-nmap <silent><buffer>  <localleader>e           :call Spawn()<cr>
-" Steve's additional mappings end here
-
-" Placeholders for already assigned but non-functional commands
-map <silent><buffer> <localleader>h :echo "VimOutliner reserved command: ,,h"<cr>
-imap <silent><buffer> <localleader>h :echo "VimOutliner reserved command: ,,h"<cr>
-map <silent><buffer> <localleader>H :echo "VimOutliner reserved command: ,,H"<cr>
-imap <silent><buffer> <localleader>H :echo "VimOutliner reserved command: ,,H"<cr>
-
-" End of Vim Outliner Key Mappings }}}1
 " Menu Entries {{{1
 " VO menu
 amenu &VO.Expand\ Level\ &1 :set foldlevel=0<cr>
@@ -674,6 +615,73 @@ if exists('g:vo_modules_load')
 	endfor
 unlet! vo_module
 endif
+
+" Vim Outliner Key Mappings {{{1
+" insert the date
+nmap <silent><buffer> <localleader>d $:call InsertSpaceDate()<cr>
+imap <silent><buffer> <localleader>d ~<esc>x:call InsertDate(0)<cr>a
+nmap <silent><buffer> <localleader>D ^:call InsertDate(1)<cr>a <esc>
+
+" insert the time
+nmap <silent><buffer> <localleader>t $:call InsertSpaceTime()<cr>
+imap <silent><buffer> <localleader>t ~<esc>x:call InsertTime(0)<cr>a
+nmap <silent><buffer> <localleader>T ^:call InsertTime(1)<cr>a <esc>
+
+" sort a list naturally
+map <silent> <buffer> <localleader>s :silent call SortChildren(0)<cr>
+" sort a list, but you supply the options
+map <silent> <buffer> <localleader>S :silent call SortChildren(1)<cr>
+
+" invoke the file explorer
+map <silent><buffer> <localleader>f :e .<cr>
+imap <silent><buffer> <localleader>f :e .<cr>
+
+" Insert a fence for segmented lists.
+" this divider is used by otl2html.py to create '<hr>'
+map <silent><buffer> <localleader>- o----------------------------------------0
+imap <silent><buffer> <localleader>- ----------------------------------------<cr>
+
+" switch document between the two types of bodytext styles
+if use_space_colon == 1
+  "   First, convert document to the marker style
+  map <silent><buffer><localleader>b :%s/\(^\t*\) :/\1/e<cr>:%s/\(^\t*\) /\1 : /e<cr>:let @/=""<cr>
+  "   Now, convert document to the space style
+  map <silent><buffer><localleader>B :%s/\(^\t*\) :/\1/e<cr>:let @/=""<cr>
+else
+  "   First, convert document to the marker style
+  map <silent><buffer><localleader>b :%s/\(^\t*\):/\1/e<cr>:%s/\(^\t*\) /\1: /e<cr>:let @/=""<cr>
+  "   Now, convert document to the space style
+  map <silent><buffer><localleader>B :%s/\(^\t*\):/\1/e<cr>:let @/=""<cr>
+endif
+
+" Steve's additional mappings start here
+map <silent><buffer>   <C-K>         <C-]>
+map <silent><buffer>   <C-N>         <C-T>
+map <silent><buffer>   <localleader>0           :set foldlevel=99999<CR>
+map <silent><buffer>   <localleader>9           :set foldlevel=8<CR>
+map <silent><buffer>   <localleader>8           :set foldlevel=7<CR>
+map <silent><buffer>   <localleader>7           :set foldlevel=6<CR>
+map <silent><buffer>   <localleader>6           :set foldlevel=5<CR>
+map <silent><buffer>   <localleader>5           :set foldlevel=4<CR>
+map <silent><buffer>   <localleader>4           :set foldlevel=3<CR>
+map <silent><buffer>   <localleader>3           :set foldlevel=2<CR>
+map <silent><buffer>   <localleader>2           :set foldlevel=1<CR>
+map <silent><buffer>   <localleader>1           :set foldlevel=0<CR>
+"next line commented out due to hard-coded nature and ancient, nonexistent file
+"map <silent><buffer>   <localleader>,,          :runtime vimoutliner/vimoutlinerrc<CR>
+map! <silent><buffer>  <localleader>w           <Esc>:w<CR>a
+nmap <silent><buffer>  <localleader>e           :call Spawn()<cr>
+" Steve's additional mappings end here
+
+" Placeholders for already assigned but non-functional commands
+map <silent><buffer> <localleader>h :echo "VimOutliner reserved command: ,,h"<cr>
+imap <silent><buffer> <localleader>h :echo "VimOutliner reserved command: ,,h"<cr>
+map <silent><buffer> <localleader>H :echo "VimOutliner reserved command: ,,H"<cr>
+imap <silent><buffer> <localleader>H :echo "VimOutliner reserved command: ,,H"<cr>
+map <silent><buffer> <localleader>c :echo "VimOutliner reserved command: ,,c"<cr>
+imap <silent><buffer> <localleader>c :echo "VimOutliner reserved command: ,,c"<cr>
+
+" End of Vim Outliner Key Mappings }}}1
 
 " The End
 " vim600: set foldmethod=marker foldlevel=0:


### PR DESCRIPTION
<localleader>-mapped commands are not dynamic, i.e. existing mappings
are not changed if <localleader> is updated after mappings have occurred.
To fix this, loading of .vimoutlinerrc must take place before the key
mappings.
1. Moved loading of .vimoutlinerrc to before key mappings.
2. Cleaned up comments a bit.
3. Removed the <localleader>,, command that forces reloading of settings.
    (this command points to non-existent configuration files anyway)
