### PR TITLE
Remove unnecessary Unicode and associated modeline

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -1,4 +1,4 @@
-*votl_readme.txt*	For Vim version 7.2	Last change: 2014-09-28
+﻿*votl_readme.txt*	For Vim version 7.2	Last change: 2014-09-28
 
                                                                 *vo* *votl* *vimoutliner*
 VimOutliner  0.4.0 ~
@@ -399,7 +399,7 @@ the files searched in the following locations will be used:
    $HOME/.vim/bundle/vimoutliner when using pathogen)
 
 Many global variables can be also set in the normal vim manner in the
-user’s $VIMRC file. See general vim documentation for more details for
+user's $VIMRC file. See general vim documentation for more details for
 individual variables.
 
                                                                   *votl-command*
@@ -411,13 +411,13 @@ with two commas. The double comma followed by a character is incredibly
 fast to type. However, with more widespread use of the VimOutliner some
 developers felt that all idiosyncrasies should be eliminated and
 VimOutliner should behave as a normal vim plugin.  Therefore now we
-don’t redefine this command leader (as it is called in the Vim lingo)
+don't redefine this command leader (as it is called in the Vim lingo)
 and unless the user redefines it on her own (in |vimoutlinerrc|) it
 defaults to backslash. If you configure VimOutliner to use different key
 combination, you have to mentally replace it everywhere in this
 documentation.
 
-If you are friend of the ancient regimé, then just uncomment the line in
+If you are friend of the ancient régime, then just uncomment the line in
 |vimoutlinerrc| (see more about the locations where you should put it):
 
     "let maplocalleader = ',,'  " uncomment for compatibility with
@@ -1303,5 +1303,3 @@ http://www.troubleshooters.com/projects/vimoutliner.htm
 Former Web page for the VimOutliner distro
 
 For the VimOutliner version information and history, see the CHANGELOG.
-
-# vim: set fileencoding=utf8 :


### PR DESCRIPTION
The latest change to votl.txt f05e091 added a modeline that generates an error every time I run :help votl

 **E21: Cannot make changes, 'modifiable' is off: fileencoding=utf8**

The error makes sense since the buffer is a non-modifiable help file. I messed around for some time trying to make it work with no success. If you really want it to be UTF-8, maybe set the [BOM](http://en.wikipedia.org/wiki/Byte_order_mark) using :set bomb.  But I don't see the point in that. The only Unicode is a couple of single quotes and the word regimé (which should be régime anyway ;-).  I've removed them and the modeline in this commit.
