### PR TITLE
Use env shebang to figure out python location

### DIFF
--- a/vimoutliner/scripts/otl2html.py
+++ b/vimoutliner/scripts/otl2html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otl2html.py
 # convert a tab-formatted outline from VIM to HTML
 #

--- a/vimoutliner/scripts/otl2ooimpress.py
+++ b/vimoutliner/scripts/otl2ooimpress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otl2ooimpress.py
 # needs otl2ooimpress.sh to work in an automated way
 #############################################################################

--- a/vimoutliner/scripts/otl2table.py
+++ b/vimoutliner/scripts/otl2table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otl2table.py
 # convert a tab-formatted outline from VIM to tab-delimited table
 #

--- a/vimoutliner/scripts/otl2tags.py
+++ b/vimoutliner/scripts/otl2tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otl2tags.py
 # Convert an OTL file to any tags-based file using config user-
 # definable configuration files. HTML, OPML, XML, LATEX and

--- a/vimoutliner/scripts/otlgrep.py
+++ b/vimoutliner/scripts/otlgrep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otlgrep.py
 # grep an outline for a regex and return the branch with all the leaves.
 #

--- a/vimoutliner/scripts/otlsplit.py
+++ b/vimoutliner/scripts/otlsplit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 # otlslit.py
 # split an outline into several files.
 #


### PR DESCRIPTION
The python scripts would not run on OS X, because of the hard coded python
path. The portability of the python scripts is increased a bit by using
/usr/bin/env to figure out where python is located.
