### PR TITLE
We want <leader>w to be active only in the normal mode, not when searching

### DIFF
--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -659,7 +659,7 @@ map <silent><buffer>   <localleader>2           :set foldlevel=1<CR>
 map <silent><buffer>   <localleader>1           :set foldlevel=0<CR>
 "next line commented out due to hard-coded nature and ancient, nonexistent file
 "map <silent><buffer>   <localleader>,,          :runtime vimoutliner/vimoutlinerrc<CR>
-map! <silent><buffer>  <localleader>w           <Esc>:w<CR>a
+nmap <silent><buffer>  <localleader>w           <Esc>:w<CR>a
 nmap <silent><buffer>  <localleader>e           :call Spawn()<cr>
 " Steve's additional mappings end here
 


### PR DESCRIPTION
Fixes #117

Please, @cche check that the issue is resolved when using `ftplugin/votl.vim` from this pull request.
