### PR TITLE
Fix in scripts/votl_maketags.py, catch os.makedirs exception

### DIFF
--- a/vimoutliner/scripts/votl_maketags.py
+++ b/vimoutliner/scripts/votl_maketags.py
@@ -22,6 +22,7 @@ from __future__ import print_function, unicode_literals
 import argparse
 import os.path
 import re
+import errno
 
 
 TAGFILENAME = os.path.expanduser("~/.vim/vimoutliner/vo_tags.tag")
@@ -59,7 +60,13 @@ def create_and_process(filename, outfile, queue, filestag):
     basedir = os.path.dirname(filename)
 
     if not os.path.exists(filename):
-        os.makedirs(basedir)
+        try:
+            os.makedirs(basedir)
+        except OSError as ose:
+            if ose.errno == errno.EEXIST and os.path.isdir(basedir):
+                pass
+            else:
+                raise
         open(filename, 'a')
         filestag[filename] = {}
     else:


### PR DESCRIPTION
In scripts/votl_maketags.py, in the function create_and_process. In case
the path of filename didn't exist, os.makedirs was called. But if
filename path doesn't exist that doesn't mean the path of the directory
containing filename doesn't exist. Because of it, the script was raising
an exception all the time. The issue has been solved by catching
os.makedirs exception and passing when the exception is because of
existing dir.