### PR TITLE
Setting the charset of the output file of otl2html to utf-8

### DIFF
--- a/vimoutliner/scripts/otl2html.py
+++ b/vimoutliner/scripts/otl2html.py
@@ -1033,7 +1033,11 @@ def printHeader(linein):
     global styleSheet, inlineStyle
     print """<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"s
         \"http://www.w3.org/TR/html4/strict.dtd\">
-    <html><head><title>""" + getTitleText(linein) + "</title></head>"
+    <html>
+        <head>
+            <meta charset="utf-8"/>
+            <title>""" + getTitleText(linein) + """</title>
+        </head>"""
     try:
         file = open(styleSheet, "r")
     except IOError:


### PR DESCRIPTION
I had some problems with file with special characters in and the otl2html.py script. So I added the utf-8 charset tag to the output of this scrip. I think this is a good solution for all, because special characters are displayed correctly. 
Perhaps we can make this more sophisticate by trying to guess the charset of the original otl file. But then we have to include some other libraries, what I tried to prevent.
