### PR TITLE
remove c_k c_n mappings, see #128

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -223,13 +223,10 @@ $HOME/.vim/vimoutliner/scripts/votl_maketags.pl $HOME/votl_test.otl
 Try the following:
 - In $HOME/votl_test.otl
 - Cursor to the _tag_newfile marker
-- Press CTRL-K
+- Press CTRL-]
     You should be brought to $HOME/votl_newfile.otl
-- Press CTRL-N
+- Press CTRL-T
     You should be brought back to $HOME/votl_test.otl
-Note:
-    CTRL-K is a VimOutliner synonym for CTRL-]
-    CTRL-N is a VimOutliner synonym for CTRL-T
 
 This might also be achieved more efficiently by using the UTL plugin for
 linking to other files and text. Check out the plugin at:
@@ -452,14 +449,18 @@ others could benefit from it.
 
 Other VimOutliner Commands~
 
-Naturally, almost all Vim commands work in VimOutliner.  Additionally,
-VimOutliner adds a few extra commands besides the comma comma commands
-discussed previously.
+Naturally, almost all Vim commands work in VimOutliner. Besides
+the comma comma commands VimOutliner suggests a few extra commands.
+To further enhance your VimOutliner experience add the following
+lines to your .vimrc file.
+>
+	map <silent> <buffer> <C-K> <Plug>VO_FollowLink
+	map <silent> <buffer> <C-N> <Plug>VO_JumpBack
+<
+which will add the following mappings
 
-Command list:
-    CTRL-K        Follow tag (Synonym for CTRL-])
-    CTRL-N        Return from tag (Synonym for CTRL-T)
-    Q             Reformat (Synonym for gq)
+<C-K>   normal  Follow tag/interoutline (Synonym for Ctrl+])
+<C-N>   normal  Return from tag (Synonym for Ctrl+T)
 
 
 To get a quick overview of all VimOutliner commands type ":help votl_cheatsheet" in vim.

--- a/doc/votl_cheatsheet.txt
+++ b/doc/votl_cheatsheet.txt
@@ -64,12 +64,6 @@ OTHER~
 ,,D   all      VimOutliner reserved command
 
 
-TAGGING/INTEROUTLINE~
-
-<C-K>   normal  Follow tag/interoutline (Synonym for Ctrl+])
-<C-N>   normal  Return from tag (Synonym for Ctrl+T)
-
-
 TIME AND DATE~
 
 ,,t   normal   Append timestamp (HH:MM:SS) to heading

--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -645,8 +645,6 @@ map <silent><buffer><localleader>b :%s/\(^\t*\):/\1/e<cr>:%s/\(^\t*\) /\1: /e<cr
 map <silent><buffer><localleader>B :%s/\(^\t*\):/\1/e<cr>:let @/=""<cr>
 
 " Steve's additional mappings start here
-map <silent><buffer>   <C-K>         <C-]>
-map <silent><buffer>   <C-N>         <C-T>
 map <silent><buffer>   <localleader>0           :set foldlevel=99999<CR>
 map <silent><buffer>   <localleader>9           :set foldlevel=8<CR>
 map <silent><buffer>   <localleader>8           :set foldlevel=7<CR>

--- a/vimoutliner/plugin/votl_tags.vim
+++ b/vimoutliner/plugin/votl_tags.vim
@@ -4,8 +4,6 @@
 " Description: This plugin provides inter-outline links for vimoutliner.
 " Maintainer:  Israel Chauca F. <israelchauca@gmail.com>
 " Manual:      The following mappings are added:
-"      					- <C-K> : Follow a link.
-"      					- <C-N> : Jump back in the link-history.
 "      					- <localleader>l : Create a link.
 " ============================================================================
 
@@ -20,20 +18,6 @@ if !exists('w:vo_jump_list')
 endif
 
 " Mappings {{{1
-
-" Follow inter-outline link.
-noremap <buffer> <Plug>VO_FollowLink :call <SID>follow_link()<CR>
-if !hasmapto('<Plug>VO_FollowLink')
-	"map <unique> <buffer> <C-K> <Plug>VO_FollowLink
-	map <silent> <buffer> <C-K> <Plug>VO_FollowLink
-endif
-
-" Go back to previous outline.
-noremap <buffer> <Plug>VO_JumpBack :call <SID>jump_back()<CR>
-if !hasmapto('<Plug>VO_JumpBack')
-	"map <unique> <buffer> <C-N> <Plug>VO_JumpBack
-	map <silent> <buffer> <C-N> <Plug>VO_JumpBack
-endif
 
 " Create a link from a word in normal mode.
 noremap <buffer> <Plug>VO_CreateLink :call <SID>create_link()<CR>

--- a/vimoutliner/scripts/outline_calendar/vo_calendar_readme.otl
+++ b/vimoutliner/scripts/outline_calendar/vo_calendar_readme.otl
@@ -169,7 +169,7 @@ Outline Calendar 1.3
 					: if you're running X, you'll get a gvim, otherwise a vim
 					: you'll be on today's entry
 				move around, add some items to the outline
-				move cursor on a ISO-format date yyyy-mm-dd and <C-k> it
+				move cursor on a ISO-format date yyyy-mm-dd and <C-]> it
 			edit any available day
 				$ td 2005-05-04
 					: release day


### PR DESCRIPTION
Don't set the mappings by default, instead
mention the possibility and how to do it in
the documentation.

Replace earlier mentions with the default
CTRL-] vim mapping.

Remove the Q mapping from the cheatsheet and the
documentation. It is not set anywhere in the code.