### PR TITLE
remove byte-order-mark (BOM) from documentation files

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -1,4 +1,4 @@
-﻿*votl_readme.txt*	For Vim version 7.2	Last change: 2014-09-28
+*votl_readme.txt*	For Vim version 7.2	Last change: 2014-09-28
 
                                                                 *vo* *votl* *vimoutliner*
 VimOutliner  0.4.0 ~

--- a/doc/votl_cheatsheet.txt
+++ b/doc/votl_cheatsheet.txt
@@ -1,4 +1,4 @@
-﻿ *votl_cheatsheet.txt*  Last change: 2013-04-06
+ *votl_cheatsheet.txt*  Last change: 2013-04-06
 
 VIMOUTLINER CHEAT SHEET~
 


### PR DESCRIPTION
This causes vim to fail when indexing them, in some situations