### PR TITLE
Fixing BSD unfriendly shebangs

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -541,7 +541,7 @@ The last tool item calls a shell script, 'myotl2html.sh'. This script should
 be provided by the user and is not included in VO releases. A sample
 myotl2html.sh script might look like this:
 >
-    #!/bin/bash
+    #!/bin/sh
     otl2html.py -S pjtstat.css $1 > $HOME/public_html/$1.html
 <
 If you have several different types of reports you create regularly, you can

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 homedir=$HOME
 vimdir=$homedir/.vim

--- a/vimoutliner/scripts/otl2ooimpress.sh
+++ b/vimoutliner/scripts/otl2ooimpress.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # otl2ooimpress.sh
 # needs otl2ooimpress.py to work at all
 #############################################################################
@@ -29,6 +29,6 @@ RMPATH=/bin
 # Path to zip
 ZIPPATH=/usr/bin
 
-$MYPATH/otl2ooimpress.py $1 > content.xml
-$ZIPPATH/zip $1.sxi content.xml
+$MYPATH/otl2ooimpress.py "$1" > content.xml
+$ZIPPATH/zip "$1.sxi" content.xml
 $RMPATH/rm content.xml

--- a/vimoutliner/scripts/otlhead.sh
+++ b/vimoutliner/scripts/otlhead.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [ "$#" -lt 1 ] ; then
 	echo " Usage: otlhead level < file"
 	echo "        Keep the number of levels specified, remove the rest."

--- a/vimoutliner/scripts/otltail.sh
+++ b/vimoutliner/scripts/otltail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [ "$#" -lt 1 ] ; then
 	echo " Usage: otltail level < file"
 	echo "	      Remove the specified number of parent headings."


### PR DESCRIPTION
`#!/usr/bin/bash` is used in several places. I've replaced these parts with `#!/usr/bin/env bash`, which also works on BSDs.