### PR TITLE
Fix renamed files in install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,12 +126,12 @@ echo "installing files"
 copyfile syntax/votl.vim $vimdir
 copyfile ftplugin/votl.vim $vimdir
 copyfile ftdetect/votl.vim $vimdir
-copyfile colors/vo_light.vim $vimdir
-copyfile colors/vo_dark.vim $vimdir
+copyfile colors/votl_light.vim $vimdir
+copyfile colors/votl_dark.vim $vimdir
 copyfile doc/votl.txt $vimdir
 copyfile doc/votl_cheatsheet.txt $vimdir
 copyfile vimoutlinerrc $vodir
-copyfile vimoutliner/scripts/votl_maketags.pl $vimdir
+copyfile vimoutliner/scripts/votl_maketags.py $vimdir
 
 #INCORPORATE HELP DOCUMENTATION
 echo "Installing vimoutliner documentation"


### PR DESCRIPTION
The `install.sh` script did not install the color files and the maketags scripts. The files have been renamed without updating the install script. I've fixed this.

For the votl_maketags.py I'm actually not sure. It looks like a replacement for votl_maketags.pl, but is it a compatible drop-in? votl_maketags.pl is referenced a couple of times in the documentation. If votl_maketags.py is the compatible successor, I will change all the references as well.