### PR TITLE
*votl-install* tag was written twice

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -60,7 +60,6 @@ Installing and Testing VimOutliner                                *votl-install*
     Manual Method                   |votl-manual-install|
     Testing                         |votl-testing|
 
-                                                                  *votl-install*
 Install~
 
 VimOutliner uses now standard method of installation of vim plugins (vim


### PR DESCRIPTION
having two of the same tag was causing an error from :helptags