### PR TITLE
Remove outdated installation links

### DIFF
--- a/doc/votl.txt
+++ b/doc/votl.txt
@@ -53,13 +53,6 @@ Absolutely no warranty, see COPYING file for details.
 ==============================================================================
 Installing and Testing VimOutliner
 
-
-    Install via Pathogen            |votl-pathogen-install|
-    Legacy Script Driven Method     |votl-auto-install|
-    Updating                        |votl-updating|
-    Manual Method                   |votl-manual-install|
-    Testing                         |votl-testing|
-
                                                                   *votl-install*
 Install~
 


### PR DESCRIPTION
13f95c85eac changed the installation mechanism of votl to use standard
vim packaging. These sections were removed, but their links were not.