### PR TITLE
Alter regex so that empty lines switch to start with colon

### DIFF
--- a/ftplugin/votl.vim
+++ b/ftplugin/votl.vim
@@ -640,7 +640,7 @@ map <silent><buffer> <localleader>- o----------------------------------------0
 imap <silent><buffer> <localleader>- ----------------------------------------<cr>
 
 "   First, convert document to the marker style
-map <silent><buffer><localleader>b :%s/\(^\t*\):/\1/e<cr>:%s/\(^\t*\) /\1: /e<cr>:let @/=""<cr>
+map <silent><buffer><localleader>b :%s/\(^\t*\):\n/\1 \r/e<cr>:%s/\(^\t*\):/\1/e<cr>:%s/\(^\t*\) /\1: /e<cr>:let @/=""<cr>
 "   Now, convert document to the space style
 map <silent><buffer><localleader>B :%s/\(^\t*\):/\1/e<cr>:let @/=""<cr>
 


### PR DESCRIPTION
This works by introducing a special case where there is an empty line,
adding a space so that the remainder of the regex do not view it as
"empty", allowing these lines to be changed back and forth with the \b
and \B remaps.

Addresses and resolves issue #160 