### PR TITLE
Remove explicit augroup handling in ftdetect

### DIFF
--- a/ftdetect/votl.vim
+++ b/ftdetect/votl.vim
@@ -19,8 +19,6 @@
 "# Steve Litt, slitt@troubleshooters.com, http://www.troubleshooters.com
 "# #######################################################################
 
-augroup filetypedetect
-  au! BufRead,BufNewFile *.otl		setfiletype votl
-  au! BufRead,BufNewFile *.oln		setfiletype xoutliner
-augroup END
+au! BufRead,BufNewFile *.otl		setfiletype votl
+au! BufRead,BufNewFile *.oln		setfiletype xoutliner
 


### PR DESCRIPTION
It is both pointless and introduces bugs, as Vim opens an `augroup filetypedetect` context before running `ftdetect` scripts anyway and other `ftdetect` scripts rely on being inside such a context, so by leaving it at the end of our `ftdetect` script we break them.

Fixes https://github.com/vimoutliner/vimoutliner/issues/185